### PR TITLE
Fix package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ Check the [releases](https://github.com/ArturKlauser/raspberrypi-rstudio/release
 if you just want to download some pre-built Debian packages.
 
 ## Installing RStudio Natively on Your Raspberry Pi
+
+> ### Note for Raspbian 10 (Buster) Users
+> At this time, the Raspbian Buster package archives that are configured by
+> default on a fresh Raspbian install are missing a few QT5 libraries which are
+> required to run RStudio Desktop. To get access to those, add the Debian package
+> archive to your archive list first.
+> ```
+> sudo cat > /etc/apt/sources.list.d/debian.list << EOF
+> deb http://deb.debian.org/debian/ buster main
+> EOF
+> curl -fsSL https://ftp-master.debian.org/keys/release-10.asc | sudo apt-key add -
+> ```
+
 Once you have extracted the .deb images from the build containers in the steps
 above, you're ready to install them natively on your Raspberry Pi. To make sure
 the dependencies are also properly installed we'll use `apt` instead of `dpkg`

--- a/balenalib-bullseye-build.sh
+++ b/balenalib-bullseye-build.sh
@@ -4,6 +4,9 @@
 # release) or Bullseye (Debian 11) containers, so this tries to build a
 # semblance of them based on their Dockerfile with some modifications.
 # See: https://github.com/balena-io-library/base-images/blob/master/balena-base-images/device-base/raspberrypi3/debian/sid/run/Dockerfile
+#
+# You need to build these containers before you try to build 'bullseye' versions
+# or RStudio with build.sh bullseye <build-stage>
 
 docker build \
   -f docker/Dockerfile.balenalib-raspberrypi3-debian-bullseye-run \

--- a/build.sh
+++ b/build.sh
@@ -46,21 +46,21 @@ function main() {
       readonly VERSION_MAJOR=1
       readonly VERSION_MINOR=1
       readonly VERSION_PATCH=463
-      readonly PACKAGE_RELEASE='2~r2r'
+      readonly PACKAGE_RELEASE='3~r2r'
       ;;
     'buster')
       # As of 2019-10-26 v1.2.5019 is the latest version 1.2 tag.
       readonly VERSION_MAJOR=1
       readonly VERSION_MINOR=2
       readonly VERSION_PATCH=5019
-      readonly PACKAGE_RELEASE='1~r2r'
+      readonly PACKAGE_RELEASE='2~r2r'
       ;;
     'bullseye')
       # As of 2019-10-26 v1.2.5019 is the latest version 1.2 tag.
       readonly VERSION_MAJOR=1
       readonly VERSION_MINOR=2
       readonly VERSION_PATCH=5019
-      readonly PACKAGE_RELEASE='1~r2r'
+      readonly PACKAGE_RELEASE='2~r2r'
       ;;
     *)
       usage "Unsupported Debian version '${DEBIAN_VERSION}'"

--- a/docker/Dockerfile.build-env
+++ b/docker/Dockerfile.build-env
@@ -116,25 +116,32 @@ RUN sed -i -e 's#libssl1.0.0 | libssl1.0.2 | libssl1.1, #libssl1.0.2, #' package
 #--- end buster
 
 # For Desktop, add the package dependencies to system QT libraries.
-RUN QT_DEPS='libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, '
+RUN echo -n 'libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ' > /tmp/x.qt_deps
 #--- begin buster
 RUN set -x; \
     if [ "${DEBIAN_VERSION}" = 'buster' ]; then \
-      QT_DEPS="${QT_DEPS}libqt5webengine5, libqt5webenginewidgets5, "; \
+      echo -n ="libqt5webengine5, libqt5webenginewidgets5, " >> /tmp/x.qt_deps; \
     fi
 #--- end buster
 #--- begin version 1.1.*
 RUN set -x; \
     if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.1' ]; then \
-      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}'"${QT_DEPS}"')#' package/linux/CMakeLists.txt; \
+      QT_DEPS=$(cat /tmp/x.qt_deps); \
+      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}'"${QT_DEPS}"'")#' package/linux/CMakeLists.txt; \
     fi
 #--- end version 1.1.*
 #--- begin version 1.2.*
 RUN set -x; \
     if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.2' ]; then \
-      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}'"${QT_DEPS}"')#' package/linux/CMakeLists.txt; \
+      QT_DEPS=$(cat /tmp/x.qt_deps); \
+      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}'"${QT_DEPS}"'")#' package/linux/CMakeLists.txt; \
     fi
 #--- end version 1.2.*
+
+# Move package recommendation for r-base to package dependency. It makes
+# little sense to install without r-base since neither server nor desktop
+# can even start without having R installed.
+RUN sed -i -e 's#set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "\(r-base.*$\)#set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, \1#' package/linux/CMakeLists.txt
 
 # Add our own package release (aka. Debian revision number) to the .deb file.
 RUN sed -i -e 's#\(^.*\)-\(${PACKAGE_ARCHITECTURE}\)#set(CPACK_DEBIAN_PACKAGE_RELEASE "'${PACKAGE_RELEASE}'")\n\1-${CPACK_DEBIAN_PACKAGE_RELEASE}_\2#' package/linux/CMakeLists.txt

--- a/docker/Dockerfile.build-env
+++ b/docker/Dockerfile.build-env
@@ -120,7 +120,7 @@ RUN echo -n 'libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors
 #--- begin buster
 RUN set -x; \
     if [ "${DEBIAN_VERSION}" = 'buster' ]; then \
-      echo -n ="libqt5webengine5, libqt5webenginewidgets5, " >> /tmp/x.qt_deps; \
+      echo -n "libqt5webengine5, libqt5webenginewidgets5, " >> /tmp/x.qt_deps; \
     fi
 #--- end buster
 #--- begin version 1.1.*

--- a/docker/Dockerfile.build-env
+++ b/docker/Dockerfile.build-env
@@ -116,16 +116,23 @@ RUN sed -i -e 's#libssl1.0.0 | libssl1.0.2 | libssl1.1, #libssl1.0.2, #' package
 #--- end buster
 
 # For Desktop, add the package dependencies to system QT libraries.
+RUN QT_DEPS='libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, '
+#--- begin buster
+RUN set -x; \
+    if [ "${DEBIAN_VERSION}" = 'buster' ]; then \
+      QT_DEPS="${QT_DEPS}libqt5webengine5, libqt5webenginewidgets5, "; \
+    fi
+#--- end buster
 #--- begin version 1.1.*
 RUN set -x; \
     if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.1' ]; then \
-      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
+      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}'"${QT_DEPS}"')#' package/linux/CMakeLists.txt; \
     fi
 #--- end version 1.1.*
 #--- begin version 1.2.*
 RUN set -x; \
     if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.2' ]; then \
-      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
+      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}'"${QT_DEPS}"')#' package/linux/CMakeLists.txt; \
     fi
 #--- end version 1.2.*
 

--- a/docker/Dockerfile.build-env
+++ b/docker/Dockerfile.build-env
@@ -119,13 +119,13 @@ RUN sed -i -e 's#libssl1.0.0 | libssl1.0.2 | libssl1.1, #libssl1.0.2, #' package
 #--- begin version 1.1.*
 RUN set -x; \
     if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.1' ]; then \
-      RUN sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
+      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
     fi
 #--- end version 1.1.*
 #--- begin version 1.2.*
 RUN set -x; \
     if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.2' ]; then \
-      RUN sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
+      sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
     fi
 #--- end version 1.2.*
 

--- a/docker/Dockerfile.build-env
+++ b/docker/Dockerfile.build-env
@@ -116,12 +116,18 @@ RUN sed -i -e 's#libssl1.0.0 | libssl1.0.2 | libssl1.1, #libssl1.0.2, #' package
 #--- end buster
 
 # For Desktop, add the package dependencies to system QT libraries.
-#--- begin stretch
-RUN sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt
-#--- end stretch
-#--- begin buster
-RUN sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "psmisc,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt
-#--- end buster
+#--- begin version 1.1.*
+RUN set -x; \
+    if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.1' ]; then \
+      RUN sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
+    fi
+#--- end version 1.1.*
+#--- begin version 1.2.*
+RUN set -x; \
+    if [ "${VERSION_MAJOR}.${VERSION_MINOR}" = '1.2' ]; then \
+      RUN sed -i -e 's#\(^.*set(RSTUDIO_DEBIAN_DEPENDS "libedit2,.*$\)#\1\nset(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libqt5webchannel5, libqt5webkit5, libqt5positioning5, libqt5sensors5, libqt5svg5, libqt5xml5, libqt5xmlpatterns5, ")#' package/linux/CMakeLists.txt; \
+    fi
+#--- end version 1.2.*
 
 # Add our own package release (aka. Debian revision number) to the .deb file.
 RUN sed -i -e 's#\(^.*\)-\(${PACKAGE_ARCHITECTURE}\)#set(CPACK_DEBIAN_PACKAGE_RELEASE "'${PACKAGE_RELEASE}'")\n\1-${CPACK_DEBIAN_PACKAGE_RELEASE}_\2#' package/linux/CMakeLists.txt


### PR DESCRIPTION
* Fix Debian package dependencies
  * The cmakefile fixup expressions were wandering astray and putting libqt5 dependencies sometimes on Server instead of Desktop debian package.
* Add dependence to QTwebengine for Desktop package:
  * The Desktop package for Raspbian Buster needs to be told explicitly that we depend on a number of dynamic libraries regarding QT webengine, otherwise apt install won't pull them in.
* Add documentation for Raspian Buster missing QT libs and how to get them
* Move r-base from package recommendation to dependency
  * It makes little sense to install without r-base since neither server nor desktop can even start without having R installed.
* Increment all package build-version numbers.